### PR TITLE
feat(cosign): Making Cosign installation optional

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,29 +11,31 @@ jobs:
     name: Test regctl-installer Action
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false # let other tests finish
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
+        cosign: [true, false]
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.0.1
+        if: matrix.cosign
+
       - name: Install regctl
         uses: ./
 
       - name: Test regctl
-        run: |
-          regctl version
-          regctl tag ls caddy
-          regctl image digest nginx:latest
-          regctl image manifest alpine:3.11
+        run: regctl version
 
   main:
-    if: ${{ github.event_name == 'push' }}
     name: Publish new version
     runs-on: ubuntu-latest
     needs: [test]
+
+    if: github.event_name == 'push'
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/IAreKyleW00t/regctl-installer/main.yml)](https://github.com/IAreKyleW00t/regctl-installer/actions/workflows/main.yml)
 [![License](https://img.shields.io/github/license/IAreKyleW00t/regctl-installer)](https://github.com/IAreKyleW00t/regctl-installer/blob/main/LICENSE)
 
-This GitHub Action enables you to interacting with remote images and registries using [`regctl`](https://github.com/google/go-containerregistry/tree/main/cmd/regctl). This action will verify the integrity of the `regctl` release during installation using [Cosign](https://docs.sigstore.dev/cosign/overview/).
+This GitHub Action enables you to interacting with remote images and registries using [`regctl`](https://github.com/google/go-containerregistry/tree/main/cmd/regctl). This action will verify the integrity of the `regctl` release during installation if you setup [Cosign](https://docs.sigstore.dev/cosign/overview/) ahead of time (see examples below).
 
 For a quick start guide on the usage of `regctl`, please refer to https://github.com/regclient/regclient/blob/main/docs/regctl.md. For available regctl releases, see https://github.com/regclient/regclient/releases.
 
@@ -18,6 +18,7 @@ For a quick start guide on the usage of `regctl`, please refer to https://github
   - [Pinned version](#pinned-version)
   - [Default version](#pinned-version)
   - [Authenicate on other registries](#authenticate-on-other-registries)
+  - [Automatic validation with Cosign](#automatic-validation-with-cosign)
 
 ## Tags
 
@@ -91,6 +92,21 @@ jobs:
           regctl registry login docker.io \
             --user "${{ vars.DOCKERHUB_USERNAME }}" \
             --pass-stdin
+```
+
+### Automatic validation with Cosign
+
+```yaml
+jobs:
+  regctl:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.0.1
+      - name: Install regctl
+        uses: iarekylew00t/regctl-installer@v1
+      - name: Check install
+        run: regctl version
 ```
 
 ## Contributing

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: sigstore/cosign-installer@v3.0.1
     - shell: bash
       run: |
         #!/bin/bash
@@ -66,15 +65,18 @@ runs:
         curl -fsSL "https://github.com/regclient/regclient/releases/download/${VERSION}/regctl-${OS}-${ARCH}${BIN_SUFFIX}" > "${{ inputs.install-dir }}/regctl${BIN_SUFFIX}"
         chmod 755 "${{ inputs.install-dir }}/regctl${BIN_SUFFIX}"
 
-        # Validate download
-        curl -fsSL https://github.com/regclient/regclient/releases/latest/download/metadata.tgz > metadata.tgz
-        tar -xzf metadata.tgz regctl-${OS}-${ARCH}.pem regctl-${OS}-${ARCH}.sig
-        cosign verify-blob \
-          --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-          --certificate-identity-regexp https://github.com/regclient/regclient/.github/workflows/ \
-          --certificate regctl-${OS}-${ARCH}.pem \
-          --signature regctl-${OS}-${ARCH}.sig \
-          "${{ inputs.install-dir }}/regctl${BIN_SUFFIX}"
+        # Validate download (if cosign is setup)
+        if which cosign >/dev/null; then
+          curl -fsSL https://github.com/regclient/regclient/releases/latest/download/metadata.tgz > metadata.tgz
+          tar -xzf metadata.tgz regctl-${OS}-${ARCH}.pem regctl-${OS}-${ARCH}.sig
+          cosign verify-blob \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --certificate-identity-regexp https://github.com/regclient/regclient/.github/workflows/ \
+            --certificate regctl-${OS}-${ARCH}.pem \
+            --signature regctl-${OS}-${ARCH}.sig \
+            "${{ inputs.install-dir }}/regctl${BIN_SUFFIX}"
+          rm -rf metadata.tgz regctl-${OS}-${ARCH}.pem regctl-${OS}-${ARCH}.sig
+        fi
 
     - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
       run: echo "${{ inputs.install-dir }}" >> $GITHUB_PATH


### PR DESCRIPTION
If the user chooses to setup the `sigstore/cosign-installer` before installing this Action, it will validate the binary automatically. Gives the user more control over what is installed on their runner, and if they want to validate things themselves or not.