### PR TITLE
feat!: No longer auto authenticating with GHCR

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,10 +23,6 @@ inputs:
     description: Perform cosign validation on regctl binary after download
     required: false
     default: "true"
-  username:
-    description: GitHub username GitHub Container Registry
-    required: false
-    default: ${{ github.actor }}
   token:
     description: GitHub Token for API and GitHub Container Registry access
     required: false
@@ -158,12 +154,3 @@ runs:
           -Encoding utf8 `
           -Append `
           -FilePath "$env:GITHUB_PATH"
-
-    - id: login
-      shell: bash
-      env:
-        TOKEN: ${{ inputs.token }}
-        USERNAME: ${{ inputs.username }}
-      run: |
-        # Login to GitHub Container Registry
-        echo "$TOKEN" | regctl registry login ghcr.io --user "$USERNAME" --pass-stdin


### PR DESCRIPTION
The following has been included in the README, as well as example, to help make this change clear.

> [!IMPORTANT]
>
> You need to authenticate into registries using either the [docker/login-action](https://github.com/docker/login-action) Action or by manually configuring credentials in within `regctl` itself. See the [Examples](#examples) section for details on how to do this.